### PR TITLE
[#20] 핸들러에서 role을 구분해서 서비스 로직에 전달하도록 리팩토링

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,7 @@ func main() {
 	{
 		userAPI.POST("/upload", imageController.UploadImage)
 		userAPI.GET("/thumbnail/:imageID/", imageController.GetThumbnail) // 썸네일 조회 엔드포인트
-		userAPI.GET("/images", imageController.GetImages)
+		userAPI.GET("/images", imageController.GetImagesByUserID)
 		userAPI.GET("/images/:imageID/", imageController.GetImageByID)
 		// 이미지 삭제
 		userAPI.DELETE("/images", imageController.DeleteAllUserImages)
@@ -48,9 +48,9 @@ func main() {
 	adminAPI.Use(middlewares.RequireAdminRole()) // 관리자 권한 미들웨어
 	{
 		adminAPI.POST("/upload/:userID/", imageController.UploadImage)
-		adminAPI.GET("/images", imageController.GetAdminImages)
-		adminAPI.GET("users/:userID/images", imageController.GetAdminImages)
-		adminAPI.GET("/images/:imageID/", imageController.GetAdminImageByID)
+		adminAPI.GET("/images", imageController.GetAllImagesByAdmin)
+		adminAPI.GET("users/:userID/images", imageController.GetImagesByUserID)
+		adminAPI.GET("/images/:imageID/", imageController.GetImageByID)
 		// 이미지 삭제
 		adminAPI.DELETE("/users/:userID/images", imageController.DeleteAllUserImages)
 		adminAPI.DELETE("/images/:imageID/", imageController.DeleteImage)

--- a/repositories/category_repository.go
+++ b/repositories/category_repository.go
@@ -9,7 +9,7 @@ type CategoryRepository interface {
 	GetCategoriesByName(names []string) ([]models.Category, error)
 	GetCategoriesByImageID(imageID uint) ([]models.Category, error)
 	GetImagesByCategoryID(categoryID uint) ([]models.Image, error)
-	GetUserImagesByCategoryID(categoryID, userID uint) ([]models.Image, error)
+	GetImagesByCategoryIDAndUserID(categoryID, userID uint) ([]models.Image, error)
 }
 
 type categoryRepository struct {
@@ -28,7 +28,7 @@ func (r *categoryRepository) GetCategoriesByName(names []string) ([]models.Categ
 	return categories, nil
 }
 
-// GetCategoriesByImageID - 특정 이미지에 속한 카테고리 조회
+// GetCategoriesByImageID 특정 이미지에 속한 카테고리 조회
 func (r *categoryRepository) GetCategoriesByImageID(imageID uint) ([]models.Category, error) {
 	var categories []models.Category
 	err := r.db.
@@ -40,7 +40,7 @@ func (r *categoryRepository) GetCategoriesByImageID(imageID uint) ([]models.Cate
 	return categories, err
 }
 
-// GetImagesByCategoryID - 특정 카테고리에 속한 이미지 조회
+// GetImagesByCategoryID 특정 카테고리에 속한 이미지 조회
 func (r *categoryRepository) GetImagesByCategoryID(categoryID uint) ([]models.Image, error) {
 	var images []models.Image
 	err := r.db.
@@ -52,8 +52,8 @@ func (r *categoryRepository) GetImagesByCategoryID(categoryID uint) ([]models.Im
 	return images, err
 }
 
-// GetUserImagesByCategoryID - 특정 카테고리에 속한 사용자의 이미지 조회
-func (r *categoryRepository) GetUserImagesByCategoryID(categoryID, userID uint) ([]models.Image, error) {
+// GetImagesByCategoryIDAndUserID 특정 카테고리에 속한 사용자의 이미지 조회
+func (r *categoryRepository) GetImagesByCategoryIDAndUserID(categoryID, userID uint) ([]models.Image, error) {
 	var images []models.Image
 	err := r.db.
 		Table("images").


### PR DESCRIPTION
### Issue Number: #20 

## 🔖 *Summary*
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.

- admin, user 권한별로 구분된 핸들러, 서비스 로직을 기능별로 통합 


## 🖊️ *Description*
필요시 요약에 대해 더 자세히 작성해주세요.
이전 구조는 각 권한에 대한 핸들러와 서비스가 중복된 코드들이 산재했다.
핸들러에서 요청한 계정의 권한을 bool(어드민이면 true, 유저면 false)로 구분하여 서비스 로직에서 권한에 따라 필요한 검증을 하고 동일한 기능을 수행한다.

현재는 권한이 어드민과 유저 뿐이어서 bool로 구분이 되지만, 권한이 추가되면 상수로 구분이 필요하다.

## ✅ *checklist*
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.